### PR TITLE
chore: Update .github/workflows/python-publish.yml

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,13 +6,26 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Publish Python 🐍 distribution 📦 to PyPI with 🔖 GitHub Release 
+name: Publish from release branch
 
-on: push
+# on: push
 
 # on:
 #  release:
 #    types: [published]
+#
+on:
+  push:
+    branches:
+      # - main
+      - release/*
+    # tags:
+    #   # Final Release tags look like: v1.11.0
+    #   - v[0-9]+.[0-9]+.[0-9]+
+    #   # Release candidate tags look like: v1.11.0-rc1
+    #   - v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+
+  # release:
+  #   types: [published]
 
 permissions:
   contents: read
@@ -75,41 +88,42 @@ jobs:
     name: >-
       Sign the Python 🐍 distribution 📦 with Sigstore
       and upload them to GitHub Release
+
     needs:
       - pypi-publish
     runs-on: ubuntu-latest
 
     permissions:
-      contents: write  # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write  # IMPORTANT: mandatory for sigstore
+      contents: write # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write # IMPORTANT: mandatory for sigstore
 
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        "$GITHUB_REF_NAME"
-        --repo "$GITHUB_REPOSITORY"
-        --notes ""
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        "$GITHUB_REF_NAME" dist/**
-        --repo "$GITHUB_REPOSITORY"
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dists
+          path: dist/
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          "$GITHUB_REF_NAME"
+          --repo "$GITHUB_REPOSITORY"
+          --notes ""
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          "$GITHUB_REF_NAME" dist/**
+          --repo "$GITHUB_REPOSITORY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["hatchling"]
+requires = [
+  "hatchling",
+  "hatch-semver"
+]
 build-backend = "hatchling.build"
 
 [project]
@@ -33,6 +36,8 @@ Source = "https://github.com/saforem2/orch"
 
 [tool.hatch.version]
 path = "src/orch/__about__.py"
+validate-bump = true
+scheme = "semver"
 
 [tool.hatch.envs.types]
 extra-dependencies = [

--- a/src/orch/__about__.py
+++ b/src/orch/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2025-present Sam Foreman <saforem2@gmail.com>
 #
 # SPDX-License-Identifier: MIT
-__version__ = "0.0.1b0"
+__version__ = "0.0.2"


### PR DESCRIPTION
## Copilot Summary

This pull request includes several changes to the workflow configuration and project files to improve the release process and version management. The most important changes involve updating the GitHub Actions workflow, modifying the project dependencies, and adjusting the versioning scheme.

### Workflow configuration updates:

* [`.github/workflows/python-publish.yml`](diffhunk://#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377L9-R28): Updated the workflow to trigger on pushes to the `release/*` branches instead of any push. This change focuses the publishing process on specific branches.
* [`.github/workflows/python-publish.yml`](diffhunk://#diff-87c8be2ac3b248aef84cc474af838d7cc461b7f8fb7f5444ac75f4d8fc02e377L90-R104): Changed the artifact name from `python-package-distributions` to `release-dists` for better clarity.

### Project dependencies and versioning:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R5): Added `hatch-semver` to the build requirements and configured the versioning scheme to use semantic versioning (`semver`). [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R5) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R39-R40)
* [`src/orch/__about__.py`](diffhunk://#diff-426192c382b23ed7734aeebb3cf417985035a5071a0bb5ad398b58ab6597f163L4-R4): Updated the project version from `0.0.1b0` to `0.0.2` to reflect the new release.